### PR TITLE
9 api statuses

### DIFF
--- a/app/Http/Controllers/API/StatusController.php
+++ b/app/Http/Controllers/API/StatusController.php
@@ -80,6 +80,11 @@ class StatusController extends Controller
         if (auth()->user()->id !== $status->user_id) {
             throw new UnauthorizedHttpException('Access Denied');
         }
+
+        if ($status->tasks()->count() > 0) {
+            return response()->json(['message' => 'Cannot delete a status with active tasks'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
         $status->delete();
         return response(null, Response::HTTP_NO_CONTENT);
     }

--- a/app/Http/Controllers/API/StatusController.php
+++ b/app/Http/Controllers/API/StatusController.php
@@ -8,12 +8,13 @@ use App\Http\Requests\UpdateStatusRequest;
 use App\Http\Resources\StatusCollectionResource;
 use App\Http\Resources\StatusResource;
 use App\Models\Status;
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class StatusController extends Controller
 {
     /**
-     * Display a listing of the resource.
+     * List statuses
      */
     public function index()
     {
@@ -26,7 +27,7 @@ class StatusController extends Controller
     }
 
     /**
-     * Store a newly created resource in storage.
+     * Store a new status
      */
     public function store(StoreStatusRequest $request)
     {
@@ -39,15 +40,14 @@ class StatusController extends Controller
         $status = Status::create($data);
 
         return new StatusResource($status);
-
     }
 
     /**
-     * Display the specified resource.
+     * Get a single status
      */
     public function show(Status $status)
     {
-        // authorize this?
+        // authorize this
         if (auth()->user()->id !== $status->user_id) {
             throw new UnauthorizedHttpException('Access Denied');
         }
@@ -72,10 +72,15 @@ class StatusController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * Delete the status
      */
     public function destroy(Status $status)
     {
-        dd($status->toArray());
+        // authorize this
+        if (auth()->user()->id !== $status->user_id) {
+            throw new UnauthorizedHttpException('Access Denied');
+        }
+        $status->delete();
+        return response(null, Response::HTTP_NO_CONTENT);
     }
 }

--- a/app/Http/Controllers/API/StatusController.php
+++ b/app/Http/Controllers/API/StatusController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreStatusRequest;
 use App\Http\Requests\UpdateStatusRequest;
+use App\Http\Resources\StatusCollectionResource;
 use App\Http\Resources\StatusResource;
 use App\Models\Status;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 class StatusController extends Controller
 {
@@ -15,7 +17,12 @@ class StatusController extends Controller
      */
     public function index()
     {
-        //
+        $statuses = Status::where('user_id', auth()->user()->id)
+            ->orderBy('position')
+            ->select('id', 'name', 'position')
+            ->get();
+
+        return new StatusCollectionResource($statuses);
     }
 
     /**
@@ -40,7 +47,11 @@ class StatusController extends Controller
      */
     public function show(Status $status)
     {
-        dd($status->toArray());
+        // authorize this?
+        if (auth()->user()->id !== $status->user_id) {
+            throw new UnauthorizedHttpException('Access Denied');
+        }
+        return new StatusResource($status);
     }
 
     /**

--- a/app/Http/Controllers/API/StatusController.php
+++ b/app/Http/Controllers/API/StatusController.php
@@ -44,11 +44,20 @@ class StatusController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * Update the status.
      */
     public function update(UpdateStatusRequest $request, Status $status)
     {
-        dd($request->all());
+        $data = $request->validated();
+        if ($data['position'] != $status->position) {
+            // update all other positions
+            Status::where('user_id', auth()->user()->id)
+            ->where('position', '>=', $data['position'])
+            ->increment('position');
+        }
+
+        $status->update($data);
+        return new StatusResource($status);
     }
 
     /**

--- a/app/Http/Controllers/API/StatusController.php
+++ b/app/Http/Controllers/API/StatusController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\API;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreStatusRequest;
 use App\Http\Requests\UpdateStatusRequest;
+use App\Http\Resources\StatusResource;
 use App\Models\Status;
 
 class StatusController extends Controller
@@ -22,7 +23,16 @@ class StatusController extends Controller
      */
     public function store(StoreStatusRequest $request)
     {
-        //
+        $data = $request->validated();
+        // update all status positions to accommodate this one
+        Status::where('user_id', auth()->user()->id)
+            ->where('position', '>=', $data['position'])
+            ->increment('position');
+        // now create this one
+        $status = Status::create($data);
+
+        return new StatusResource($status);
+
     }
 
     /**
@@ -30,7 +40,7 @@ class StatusController extends Controller
      */
     public function show(Status $status)
     {
-        //
+        dd($status->toArray());
     }
 
     /**
@@ -38,7 +48,7 @@ class StatusController extends Controller
      */
     public function update(UpdateStatusRequest $request, Status $status)
     {
-        //
+        dd($request->all());
     }
 
     /**
@@ -46,6 +56,6 @@ class StatusController extends Controller
      */
     public function destroy(Status $status)
     {
-        //
+        dd($status->toArray());
     }
 }

--- a/app/Http/Requests/StoreStatusRequest.php
+++ b/app/Http/Requests/StoreStatusRequest.php
@@ -17,10 +17,25 @@ class StoreStatusRequest extends FormRequest
 
         return [
             'name' => [
-                'required',
-                'string',
-                Rule::unique('statuses')->where(fn($query) => $query->where(['name' => request()->name, 'user_id' => auth()->user()->id]))],
+                    'required',
+                    'string',
+                    Rule::unique('statuses')->where(fn($query) => $query->where(['name' => request()->name, 'user_id' => auth()->user()->id]))
+                ],
             'position' => 'required|integer|gt:0'
         ];
     }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'Status name is required.',
+            'name.string' => 'Status name must be text.',
+            'name.unique' => 'Status name already used.',
+            'position.required' => 'Position is required.',
+            'position,integer' => 'Position must be a number',
+            'position.gt' => 'Position must be a number greater than zero',
+        ];
+    }
+
+
 }

--- a/app/Http/Requests/StoreStatusRequest.php
+++ b/app/Http/Requests/StoreStatusRequest.php
@@ -3,26 +3,24 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreStatusRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
     public function authorize(): bool
     {
-        return false;
+        return !empty(auth()->user());
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
-     */
     public function rules(): array
     {
+
         return [
-            //
+            'name' => [
+                'required',
+                'string',
+                Rule::unique('statuses')->where(fn($query) => $query->where(['name' => request()->name, 'user_id' => auth()->user()->id]))],
+            'position' => 'required|integer|gt:0'
         ];
     }
 }

--- a/app/Http/Requests/StoreStatusRequest.php
+++ b/app/Http/Requests/StoreStatusRequest.php
@@ -36,6 +36,4 @@ class StoreStatusRequest extends FormRequest
             'position.gt' => 'Position must be a number greater than zero',
         ];
     }
-
-
 }

--- a/app/Http/Requests/UpdateStatusRequest.php
+++ b/app/Http/Requests/UpdateStatusRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateStatusRequest extends FormRequest
 {
@@ -11,18 +12,35 @@ class UpdateStatusRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+         return !empty(auth()->user()) && auth()->user()->id === $this->status->user_id;
     }
 
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\Rule|array|string>
-     */
     public function rules(): array
     {
+
         return [
-            //
+            'name' => [
+                    'required',
+                    'string',
+                    Rule::unique('statuses')->where(function($query)  {
+                        $query->where(['name' => request()->name, 'user_id' => auth()->user()->id])
+                            ->whereNot(['id' => $this->status->id]);
+
+                    })
+                ],
+            'position' => 'required|integer|gt:0'
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'Status name is required.',
+            'name.string' => 'Status name must be text.',
+            'name.unique' => 'Status name already used.',
+            'position.required' => 'Position is required.',
+            'position,integer' => 'Position must be a number',
+            'position.gt' => 'Position must be a number greater than zero',
         ];
     }
 }

--- a/app/Http/Resources/StatusCollectionResource.php
+++ b/app/Http/Resources/StatusCollectionResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class StatusCollectionResource extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @return array<int|string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+         return [
+            'data' => $this->collection,
+            'links' => [
+                'self' => 'link-value',
+            ],
+        ];
+    }
+}

--- a/app/Http/Resources/StatusResource.php
+++ b/app/Http/Resources/StatusResource.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StatusResource extends JsonResource
+{
+     public static $wrap = null;
+
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'position' => $this->position
+        ];
+    }
+}

--- a/app/Models/Status.php
+++ b/app/Models/Status.php
@@ -7,11 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use App\Models\Concerns\UsesUuid;
 use App\Models\Concerns\UsesUserId;
-
+use App\Models\Relationships\StatusRelationship;
 
 class Status extends Model
 {
-    use HasFactory, SoftDeletes, UsesUuid, UsesUserId;
+    use HasFactory, SoftDeletes, UsesUuid, UsesUserId, StatusRelationship;
 
     protected $fillable = [
       'name',

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\API\StatusController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\API\AuthController;
@@ -19,9 +20,17 @@ Route::post('/register', [AuthController::class, 'register'])->name('api.registe
 Route::post('/login', [AuthController::class, 'login'])->name('api.login');
 
 Route::group(['middleware' => ['auth:sanctum']], function() {
+
     Route::get('/user', function (Request $request) {
         return $request->user();
     })->name('api.user');
 
     Route::post('/logout', [AuthController::class, 'logout'])->name('api.logout');
+
+    // Status routes
+
+    Route::prefix('status')->group(function() {
+       Route::get('/{status}', [StatusController::class, 'show'])->name('api.status.get');
+       Route::post('/', [StatusController::class, 'store'])->name('api.status.create');
+    });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,5 +32,6 @@ Route::group(['middleware' => ['auth:sanctum']], function() {
     Route::prefix('status')->group(function() {
        Route::get('/{status}', [StatusController::class, 'show'])->name('api.status.get');
        Route::post('/', [StatusController::class, 'store'])->name('api.status.create');
+       Route::put('/{status}', [StatusController::class, 'update'])->name('api.status.update');
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,5 +34,6 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
         Route::get('/{status}', [StatusController::class, 'show'])->name('api.status.get');
         Route::post('/', [StatusController::class, 'store'])->name('api.status.create');
         Route::put('/{status}', [StatusController::class, 'update'])->name('api.status.update');
+        Route::delete('/{status}', [StatusController::class, 'destroy'])->name('api.status.delete');
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,7 +19,7 @@ use App\Http\Controllers\API\AuthController;
 Route::post('/register', [AuthController::class, 'register'])->name('api.register');
 Route::post('/login', [AuthController::class, 'login'])->name('api.login');
 
-Route::group(['middleware' => ['auth:sanctum']], function() {
+Route::group(['middleware' => ['auth:sanctum']], function () {
 
     Route::get('/user', function (Request $request) {
         return $request->user();
@@ -29,9 +29,10 @@ Route::group(['middleware' => ['auth:sanctum']], function() {
 
     // Status routes
 
-    Route::prefix('status')->group(function() {
-       Route::get('/{status}', [StatusController::class, 'show'])->name('api.status.get');
-       Route::post('/', [StatusController::class, 'store'])->name('api.status.create');
-       Route::put('/{status}', [StatusController::class, 'update'])->name('api.status.update');
+    Route::prefix('status')->group(function () {
+        Route::get('/', [StatusController::class, 'index'])->name('api.status.list');
+        Route::get('/{status}', [StatusController::class, 'show'])->name('api.status.get');
+        Route::post('/', [StatusController::class, 'store'])->name('api.status.create');
+        Route::put('/{status}', [StatusController::class, 'update'])->name('api.status.update');
     });
 });

--- a/tests/Feature/Http/Controllers/API/StatusControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/StatusControllerTest.php
@@ -269,4 +269,25 @@ class StatusControllerTest extends TestCase
         $this->assertDatabaseHas('statuses', ['name' => 'Status 3', 'position' => 4]);
 
     }
+
+    public function test_delete_a_status()
+    {
+        $user = User::factory()->create();
+        // add three new statuses so that we can check the position update
+        DB::table('statuses')->insert([
+            ['id' => (string)Str::uuid(), 'name' => 'Status 1', 'position' => 1, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 2', 'position' => 2, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 3', 'position' => 3, 'user_id' => $user->id, 'created_at' => now()]
+        ]);
+
+        $status = Status::where('name', 'Status 1')->first();
+
+        Sanctum::actingAs($user, ['*']);
+
+        $uri = route('api.status.delete', [$status]);
+        $response = $this->deleteJson($uri);
+
+        $response->assertStatus(Response::HTTP_NO_CONTENT);
+        $this->assertSoftDeleted('statuses', ['id' => $status->id, 'name' => $status->name, 'user_id' => $user->id]);
+    }
 }

--- a/tests/Feature/Http/Controllers/API/StatusControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/StatusControllerTest.php
@@ -2,24 +2,57 @@
 
 namespace Tests\Feature\Http\Controllers\API;
 
+use App\Models\Status;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
 class StatusControllerTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function testStatusAuthFail()
     {
-        $this->markTestIncomplete('not finished yet');
-        $url = route('api.status.get', ['id' => 1]);
-
+        $url = route('api.status.get', ['status' => '1ba5e529-b47f-4124-afe1-4bd6cdd4c969']);
         $response = $this->get($url);
+        $this->assertSame(302, $response->status());
+    }
 
+    public function test_create_new_status()
+    {
+        $user = User::factory()->create();
 
-        $this->assertSame(403, $response->status());
+        // add three new statuses so that we can check the position update
 
+        DB::table('statuses')->insert([
+            ['id' => (string)Str::uuid(), 'name' => 'Status 1', 'position' => 1, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 2', 'position' => 2, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 3', 'position' => 3, 'user_id' => $user->id, 'created_at' => now()]
+        ]);
 
+        Sanctum::actingAs($user,  ['*']);
 
+        $formData = [
+            'name' => 'New Status',
+            'position' => 2
+        ];
+
+        $uri = route('api.status.create');
+
+        $response = $this->post($uri, $formData);
+
+        $response->assertStatus(Response::HTTP_CREATED);
+        $response->assertJson($formData);
+        $this->assertDatabaseHas('statuses', $formData);
+
+        // validate the positions were updated
+        $this->assertDatabaseHas('statuses', ['name' => 'Status 1', 'position' => 1]);
+        $this->assertDatabaseHas('statuses', ['name' => 'Status 2', 'position' => 3]);
+        $this->assertDatabaseHas('statuses', ['name' => 'Status 3', 'position' => 4]);
     }
 
 

--- a/tests/Feature/Http/Controllers/API/StatusControllerTest.php
+++ b/tests/Feature/Http/Controllers/API/StatusControllerTest.php
@@ -22,6 +22,69 @@ class StatusControllerTest extends TestCase
         $this->assertSame(302, $response->status());
     }
 
+    public function test_list_statuses()
+    {
+        $user = User::factory()->create();
+        // add three new statuses so that we can check the position update
+        DB::table('statuses')->insert([
+            ['id' => (string)Str::uuid(), 'name' => 'Status 1', 'position' => 1, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 2', 'position' => 2, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 3', 'position' => 3, 'user_id' => $user->id, 'created_at' => now()]
+        ]);
+
+        $statuses = Status::all();
+
+        Sanctum::actingAs($user, ['*']);
+
+        $uri = route('api.status.list');
+        $response = $this->getJson($uri);
+
+        $response->assertOk();
+        $response->assertJson(['data' => [
+            [
+                'id' => $statuses[0]->id,
+                'name' => $statuses[0]->name,
+                'position' => $statuses[0]->position
+            ],
+            [
+                'id' => $statuses[1]->id,
+                'name' => $statuses[1]->name,
+                'position' => $statuses[1]->position
+            ],
+            [
+                'id' => $statuses[2]->id,
+                'name' => $statuses[2]->name,
+                'position' => $statuses[2]->position
+            ],
+        ]]);
+
+    }
+
+    public function test_get_a_status()
+    {
+        $user = User::factory()->create();
+        // add three new statuses so that we can check the position update
+        DB::table('statuses')->insert([
+            ['id' => (string)Str::uuid(), 'name' => 'Status 1', 'position' => 1, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 2', 'position' => 2, 'user_id' => $user->id, 'created_at' => now()],
+            ['id' => (string)Str::uuid(), 'name' => 'Status 3', 'position' => 3, 'user_id' => $user->id, 'created_at' => now()]
+        ]);
+
+        $status = Status::where('name', 'Status 2')->first();
+
+        Sanctum::actingAs($user, ['*']);
+
+        $uri = route('api.status.get', [$status]);
+        $response = $this->getJson($uri);
+
+        $response->assertOk();
+        $response->assertJson([
+            'id' => $status->id,
+            'name' => $status->name,
+            'position' => $status->position,
+        ]);
+    }
+
 
     public function test_create_new_status_validation()
     {
@@ -202,8 +265,8 @@ class StatusControllerTest extends TestCase
         $response->assertJson($formData);
 
         $this->assertDatabaseHas('statuses', $formData);
-        $this->assertDatabaseHas('statuses', ['name' => 'Status 1' , 'position' => 2]);
-        $this->assertDatabaseHas('statuses', ['name' => 'Status 3' , 'position' => 4]);
+        $this->assertDatabaseHas('statuses', ['name' => 'Status 1', 'position' => 2]);
+        $this->assertDatabaseHas('statuses', ['name' => 'Status 3', 'position' => 4]);
 
     }
 }


### PR DESCRIPTION
This commit adds API endpoints to manage Statuses:

- get single status
- list statuses
- create a status
- update a status
- delete a status (if no tasks assigned)